### PR TITLE
Add `s3_bucket_force_destroy` variable to make S3 bucket destoyable.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,7 @@ resource "random_string" "random" {
 
 resource "aws_s3_bucket" "logs" {
   bucket = lower("${random_string.random.keepers.name_prefix}-logs-${random_string.random.result}")
+  force_destroy = var.s3_bucket_force_destroy
   tags = merge(
     var.tags,
     {

--- a/variables.tf
+++ b/variables.tf
@@ -46,3 +46,9 @@ variable "s3_bucket_server_side_encryption_key" {
   type        = string
   default     = null
 }
+
+variable "s3_bucket_force_destroy" {
+  description = "(Optional) Sets force_destroy attribute on the generated S3 bucket."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
That option is useful in staging environments where we want to make S3 bucket destroyable using `terraform destroy` even when the bucket is not empty. Otherwise to destroy a ECS fargate service one needs to run `terraform destroy` which fails on destroying the bucket, then manually delete data from the bucket and then run `terraform destroy` again. 