### PR TITLE
Set ownership control to BucketOwnerPreferred

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "random_string" "random" {
 }
 
 resource "aws_s3_bucket" "logs" {
-  bucket = lower("${random_string.random.keepers.name_prefix}-logs-${random_string.random.result}")
+  bucket        = lower("${random_string.random.keepers.name_prefix}-logs-${random_string.random.result}")
   force_destroy = var.s3_bucket_force_destroy
   tags = merge(
     var.tags,
@@ -24,9 +24,9 @@ resource "aws_s3_bucket" "logs" {
 }
 
 resource "aws_s3_bucket_acl" "logs" {
-  bucket = aws_s3_bucket.logs.id
+  bucket     = aws_s3_bucket.logs.id
   depends_on = [aws_s3_bucket_ownership_controls.logs]
-  acl    = "log-delivery-write"
+  acl        = "log-delivery-write"
 }
 
 resource "aws_s3_bucket_ownership_controls" "logs" {

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,16 @@ resource "aws_s3_bucket" "logs" {
 
 resource "aws_s3_bucket_acl" "logs" {
   bucket = aws_s3_bucket.logs.id
+  depends_on = [aws_s3_bucket_ownership_controls.logs]
   acl    = "log-delivery-write"
+}
+
+resource "aws_s3_bucket_ownership_controls" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {


### PR DESCRIPTION
ACLs are no longer supported by default on S3 buckets, so attempting to create ACLs for buckets fails unless additional steps are taken. See https://github.com/hashicorp/terraform-provider-aws/issues/28353

Encountered this error via dependency on [cn-terraform/terraform-aws-ecs-fargate-service](https://github.com/cn-terraform/terraform-aws-ecs-fargate-service) which our code depends on [here](https://github.com/civiform/cloud-deploy-infra/blob/main/cloud/aws/templates/aws_oidc/app.tf#L339).

```
│ Error: error creating S3 bucket ACL for bion-dev-civiform-lb-logs-yuvyztq: AccessControlListNotSupported: The bucket does not allow ACLs
│ 	status code: 400, request id: N8HFPCG868GXEFV8, host id: EsZ6XRp8D81sKcExWgaeVGc3EEHTV8qeFpCziDb8Nq3FZDts1fHu1rqXPRxHntffJes8rfRIYos=
│
│   with module.ecs_fargate_service.module.ecs-alb[0].module.lb_logs_s3[0].aws_s3_bucket_acl.logs,
│   on .terraform/modules/ecs_fargate_service.ecs-alb.lb_logs_s3/main.tf line 26, in resource "aws_s3_bucket_acl" "logs":
│   26: resource "aws_s3_bucket_acl" "logs" {
```